### PR TITLE
Partial for #33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,7 @@ _static/
 build/
 docs/.DS_Store
 docs/build/
+*.egg-info
 
-
+venv/
+.venv/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinxcontrib.redoc',
     'sphinx.ext.autosectionlabel',
+    'sphinx-prompt',
     'sphinx_substitution_extensions',
     'sphinx_copybutton'
 ]


### PR DESCRIPTION
## 🗒️ Summary

Merge this to get Sphinx docs building in pds-api. Note that [this PR](https://github.com/NASA-PDS/github-actions-base/pull/35) must also be merged and the new `:stable` tag for the `docker.io/nasapds/github-actions-base` image be created.

## ⚙️ Test Data and/or Report

https://github.com/nasa-pds-engineering-node/pds-api/actions/runs/4894679452

## ♻️ Related Issues

- #33 
