### PR TITLE
Add documentation on XML attribute handling across response formats

### DIFF
--- a/docs/source/guides/search/responses.rst
+++ b/docs/source/guides/search/responses.rst
@@ -525,47 +525,55 @@ values in PDS4 labels. are detailed with a nil:reason attribute.
 
 
 XML Attributes in Responses
------------------------------
+---------------------------
 
 PDS4 labels encode metadata in both element text content and XML attributes (e.g., ``unit``, ``xsi:nil``, ``nilReason``).
 Whether these attributes appear in the response — and whether they are searchable — depends on the response format.
 
-+------------------------------------+-----------------------------+------------------------+
-| Response Format                    | XML Attributes Preserved?   | Searchable/Filterable? |
-+====================================+=============================+========================+
-| ``application/json``               | No                          | No                     |
-+------------------------------------+-----------------------------+------------------------+
-| ``application/xml``                | No                          | No                     |
-+------------------------------------+-----------------------------+------------------------+
-| ``application/kvp+json``           | No                          | No                     |
-+------------------------------------+-----------------------------+------------------------+
-| ``text/csv``                       | No                          | No                     |
-+------------------------------------+-----------------------------+------------------------+
-| ``application/vnd.nasa.pds.pds4+json`` | Yes                     | No                     |
-+------------------------------------+-----------------------------+------------------------+
-| ``application/vnd.nasa.pds.pds4+xml``  | Yes                     | No                     |
-+------------------------------------+-----------------------------+------------------------+
++----------------------------------------+-----------------------------+------------------------+
+| Response Format                        | XML Attributes Preserved?   | Searchable/Filterable? |
++========================================+=============================+========================+
+| ``application/json``                   | No                          | No                     |
++----------------------------------------+-----------------------------+------------------------+
+| ``application/xml``                    | No                          | No                     |
++----------------------------------------+-----------------------------+------------------------+
+| ``application/kvp+json``               | No                          | No                     |
++----------------------------------------+-----------------------------+------------------------+
+| ``text/csv``                           | No                          | No                     |
++----------------------------------------+-----------------------------+------------------------+
+| ``text/html``                          | No                          | No                     |
++----------------------------------------+-----------------------------+------------------------+
+| ``application/vnd.nasa.pds.pds4+json`` | Yes                         | No                     |
++----------------------------------------+-----------------------------+------------------------+
+| ``application/vnd.nasa.pds.pds4+xml``  | Yes                         | No                     |
++----------------------------------------+-----------------------------+------------------------+
 
-The ``pds4+json`` and ``pds4+xml`` formats directly translate the original PDS4 XML label into the response,
-so XML attribute values are preserved. For example, given a label element:
-
-.. code-block:: xml
-
-   <solar_longitude unit="deg">326.350</solar_longitude>
-
-**application/vnd.nasa.pds.pds4+xml** returns:
+The ``pds4+json`` and ``pds4+xml`` formats embed the original PDS4 XML label in the response (wrapped in
+API envelope elements), preserving all XML attribute values. For example, a label element:
 
 .. code-block:: xml
 
    <solar_longitude unit="deg">326.350</solar_longitude>
+
+**application/vnd.nasa.pds.pds4+xml** preserves the attribute inside the API wrapper:
+
+.. code-block:: xml
+
+   <pds_api:product ...>
+     ...
+     <solar_longitude unit="deg">326.350</solar_longitude>
+     ...
+   </pds_api:product>
 
 **application/vnd.nasa.pds.pds4+json** returns:
 
 .. code-block:: json
 
-   "solar_longitude": {
-     "content": "326.350",
-     "unit": "deg"
+   {
+     "solar_longitude": {
+       "content": "326.350",
+       "unit": "deg"
+     }
    }
 
 The default ``application/json`` and ``application/kvp+json`` formats are built from the search index,

--- a/docs/source/guides/search/responses.rst
+++ b/docs/source/guides/search/responses.rst
@@ -522,3 +522,59 @@ We conform to EDR specification for this aspect, see `EDR parameter response <ht
 
 This should not be mistaken for an actual PDS4 value since missing
 values in PDS4 labels. are detailed with a nil:reason attribute.
+
+
+XML Attributes in Responses
+-----------------------------
+
+PDS4 labels encode metadata in both element text content and XML attributes (e.g., ``unit``, ``xsi:nil``, ``nilReason``).
+Whether these attributes appear in the response — and whether they are searchable — depends on the response format.
+
++------------------------------------+-----------------------------+------------------------+
+| Response Format                    | XML Attributes Preserved?   | Searchable/Filterable? |
++====================================+=============================+========================+
+| ``application/json``               | No                          | No                     |
++------------------------------------+-----------------------------+------------------------+
+| ``application/xml``                | No                          | No                     |
++------------------------------------+-----------------------------+------------------------+
+| ``application/kvp+json``           | No                          | No                     |
++------------------------------------+-----------------------------+------------------------+
+| ``text/csv``                       | No                          | No                     |
++------------------------------------+-----------------------------+------------------------+
+| ``application/vnd.nasa.pds.pds4+json`` | Yes                     | No                     |
++------------------------------------+-----------------------------+------------------------+
+| ``application/vnd.nasa.pds.pds4+xml``  | Yes                     | No                     |
++------------------------------------+-----------------------------+------------------------+
+
+The ``pds4+json`` and ``pds4+xml`` formats directly translate the original PDS4 XML label into the response,
+so XML attribute values are preserved. For example, given a label element:
+
+.. code-block:: xml
+
+   <solar_longitude unit="deg">326.350</solar_longitude>
+
+**application/vnd.nasa.pds.pds4+xml** returns:
+
+.. code-block:: xml
+
+   <solar_longitude unit="deg">326.350</solar_longitude>
+
+**application/vnd.nasa.pds.pds4+json** returns:
+
+.. code-block:: json
+
+   "solar_longitude": {
+     "content": "326.350",
+     "unit": "deg"
+   }
+
+The default ``application/json`` and ``application/kvp+json`` formats are built from the search index,
+which currently indexes only element text content. XML attributes such as ``unit``, ``xsi:nil``, and
+``nilReason`` are not yet indexed and therefore do not appear in these formats and cannot be searched or filtered.
+
+Support for indexing and searching XML attribute values is planned. See:
+
+- `Registry Loader — index XML attributes from PDS4 label elements <https://github.com/NASA-PDS/registry-loader/issues/92>`_
+- `Registry API — search and filter on XML attribute values <https://github.com/NASA-PDS/registry-api/issues/789>`_
+
+For further discussion, see `How are XML attributes represented in the PDS Registry and API? <https://github.com/NASA-PDS/pds-api/discussions/300>`_

--- a/docs/spec/pds-api-specification.md
+++ b/docs/spec/pds-api-specification.md
@@ -185,6 +185,40 @@ Response Formats
 
 ~~Working~~ Document: [PDS API - Response Formats](pds-api-response-formats.pdf)
 
+### XML Attributes and Response Formats
+
+PDS4 labels encode metadata in both element text content and XML attributes (e.g., `unit`, `xsi:nil`, `nilReason`). How these attributes appear depends on the response format requested:
+
+| Response Format | XML Attributes Available? | Searchable/Filterable? |
+|---|---|---|
+| `application/json` | No | No |
+| `application/kvp+json` | No | No |
+| `application/vnd.nasa.pds.pds4+json` | Yes | No |
+| `application/vnd.nasa.pds.pds4+xml` | Yes | No |
+
+The `pds4+json` and `pds4+xml` formats directly translate the original PDS4 XML label into the response, so XML attribute values are preserved. For example, a `solar_longitude` element with a `unit` attribute:
+
+**`application/vnd.nasa.pds.pds4+xml`:**
+```xml
+<solar_longitude unit="deg">326.350</solar_longitude>
+```
+
+**`application/vnd.nasa.pds.pds4+json`:**
+```json
+"solar_longitude": {
+  "content": "326.350",
+  "unit": "deg"
+}
+```
+
+In contrast, the default `application/json` and `application/kvp+json` formats are built from the search index, which currently indexes only element text content — XML attributes are not yet indexed and therefore not searchable or filterable.
+
+Support for indexing and searching XML attribute values is planned:
+- Registry Loader: https://github.com/NASA-PDS/registry-loader/issues/92
+- Registry API: https://github.com/NASA-PDS/registry-api/issues/789
+
+See also: [pds-api discussion — How are XML attributes represented in the PDS Registry and API?](https://github.com/NASA-PDS/pds-api/discussions/300)
+
 
 Query Parameters
 ----------------

--- a/docs/spec/pds-api-specification.md
+++ b/docs/spec/pds-api-specification.md
@@ -189,33 +189,42 @@ Response Formats
 
 PDS4 labels encode metadata in both element text content and XML attributes (e.g., `unit`, `xsi:nil`, `nilReason`). How these attributes appear depends on the response format requested:
 
-| Response Format | XML Attributes Available? | Searchable/Filterable? |
+| Response Format | XML Attributes Preserved? | Searchable/Filterable? |
 |---|---|---|
 | `application/json` | No | No |
+| `application/xml` | No | No |
 | `application/kvp+json` | No | No |
+| `text/csv` | No | No |
+| `text/html` | No | No |
 | `application/vnd.nasa.pds.pds4+json` | Yes | No |
 | `application/vnd.nasa.pds.pds4+xml` | Yes | No |
 
-The `pds4+json` and `pds4+xml` formats directly translate the original PDS4 XML label into the response, so XML attribute values are preserved. For example, a `solar_longitude` element with a `unit` attribute:
+The `pds4+json` and `pds4+xml` formats embed the original PDS4 XML label in the response (wrapped in API envelope elements), preserving all XML attribute values. For example, a `solar_longitude` element with a `unit` attribute:
 
-**`application/vnd.nasa.pds.pds4+xml`:**
+**`application/vnd.nasa.pds.pds4+xml`** preserves the attribute inside the API wrapper:
 ```xml
-<solar_longitude unit="deg">326.350</solar_longitude>
+<pds_api:product ...>
+  ...
+  <solar_longitude unit="deg">326.350</solar_longitude>
+  ...
+</pds_api:product>
 ```
 
 **`application/vnd.nasa.pds.pds4+json`:**
 ```json
-"solar_longitude": {
-  "content": "326.350",
-  "unit": "deg"
+{
+  "solar_longitude": {
+    "content": "326.350",
+    "unit": "deg"
+  }
 }
 ```
 
-In contrast, the default `application/json` and `application/kvp+json` formats are built from the search index, which currently indexes only element text content — XML attributes are not yet indexed and therefore not searchable or filterable.
+In contrast, the default `application/json` and `application/kvp+json` formats are built from the search index, which currently indexes only element text content — XML attributes are not yet indexed and therefore do not appear in these formats and cannot be searched or filtered.
 
 Support for indexing and searching XML attribute values is planned:
-- Registry Loader: https://github.com/NASA-PDS/registry-loader/issues/92
-- Registry API: https://github.com/NASA-PDS/registry-api/issues/789
+- [Registry Loader — index XML attributes from PDS4 label elements](https://github.com/NASA-PDS/registry-loader/issues/92)
+- [Registry API — search and filter on XML attribute values](https://github.com/NASA-PDS/registry-api/issues/789)
 
 See also: [pds-api discussion — How are XML attributes represented in the PDS Registry and API?](https://github.com/NASA-PDS/pds-api/discussions/300)
 


### PR DESCRIPTION
## Summary

- Documents how PDS4 XML attributes (e.g., `unit`, `xsi:nil`, `nilReason`) are handled across the different API response formats
- Adds a comparison table showing which formats preserve attributes (`pds4+json`, `pds4+xml`) vs. which do not
- Explains why attribute values are not currently searchable and links to the requirements tracking the fix
- Updates both `docs/source/guides/search/responses.rst` (online docs) and `docs/spec/pds-api-specification.md`

## Related Issues

Closes NASA-PDS/registry-api#791
See also: NASA-PDS/registry-api#789, NASA-PDS/registry-loader#92, https://github.com/NASA-PDS/pds-api/discussions/300

## Test plan

- [ ] Verify RST renders correctly in Sphinx (no table formatting errors)
- [ ] Confirm links to GitHub issues and discussion resolve correctly
- [ ] Review content accuracy against current API behavior

🤖 Generated with [Claude Code](https://claude.ai/claude-code)